### PR TITLE
Jakub result bugfixes

### DIFF
--- a/forloop_modules/errors/errors.py
+++ b/forloop_modules/errors/errors.py
@@ -6,7 +6,7 @@ class CriticalPipelineError(Exception):
     pipeline flow, and it's execution must be terminated.
 
     Must always be raised with 'raise ... from error' clause to retain the information about
-    original errror.
+    original error.
     """
 
 
@@ -19,7 +19,7 @@ class SoftPipelineError(Exception):
     the current node execution without any pipeline flow disruption.
 
     Must always be raised with 'raise ... from error' clause to retain the information about
-    original errror.
+    original error.
     """
 
 
@@ -31,7 +31,7 @@ class MalformedPipelineError(Exception):
     - graph initialization fails due to incompatible pipeline elements
     - not passing a pipeline validation rule (no logic implemented yet)
 
-    Must always be raised with 'raise ... from error' clause to retain the information about original errror.
+    Must always be raised with 'raise ... from error' clause to retain the information about original error.
     """
 
 

--- a/forloop_modules/errors/errors.py
+++ b/forloop_modules/errors/errors.py
@@ -12,11 +12,11 @@ class CriticalPipelineError(Exception):
 
 class SoftPipelineError(Exception):
     """
-    Exception used for handling node-breaking, but non-pipeline-breaking errors during function_handler runtime.
+    Exception used for handling node-breaking, but non-pipeline-breaking errors during
+    function_handler runtime.
 
-    It should be raised only in case of a recoverable node errors, when the ExecutionCore can omit
-    execution of a given node and continue execution of a pipeline without any pipeline flow
-    disruption.
+    It should be raised only in case of a recoverable errors, when the ExecutionCore can omit
+    the current node execution without any pipeline flow disruption.
 
     Must always be raised with 'raise ... from error' clause to retain the information about
     original errror.

--- a/forloop_modules/function_handlers/webscraping_handlers.py
+++ b/forloop_modules/function_handlers/webscraping_handlers.py
@@ -237,7 +237,7 @@ class NextPageHandler:
             )
             page_count = int(page_count_string)
             new_url = f"{url_prefix}{page_count + 1}{url_suffix}"
-        except Exception as e: #(AttributeError, ValueError, TypeError, IndexError) as e:
+        except Exception as e:
             raise CriticalPipelineError("NextPage handler failed to execute") from e
 
         variable_handler.new_variable(page_varname, new_url)

--- a/forloop_modules/globals/active_entity_tracker.py
+++ b/forloop_modules/globals/active_entity_tracker.py
@@ -1,5 +1,6 @@
 
 import requests
+from typing import Optional
 
 from pathlib import Path
 import sys
@@ -82,7 +83,12 @@ class ActiveEntityTracker:
         self.project_uid = json.loads(project_response.content.decode('utf-8'))["uid"]
         pipeline_response = initialize_last_or_new_pipeline(self.project_uid)
         self.active_pipeline_uid= json.loads(pipeline_response.content.decode('utf-8'))["uid"]
-    
-    
-  
+
+    def set_project_and_pipeline_uid(
+        self, project_uid: Optional[str] = None, pipeline_uid: Optional[str] = None
+    ) -> None:
+        self.project_uid = project_uid if project_uid is not None else self.project_uid
+        self.active_pipeline_uid = pipeline_uid if pipeline_uid is not None else self.active_pipeline_uid
+
+
 aet=ActiveEntityTracker()

--- a/forloop_modules/queries/node_context_requests_backend.py
+++ b/forloop_modules/queries/node_context_requests_backend.py
@@ -535,11 +535,12 @@ def get_last_active_dataframe_node_uid():
 #     return response
 
 
-
 def get_variable_by_name(variable_name: str):
-    url = f'{BASE_API}/variables?name={variable_name}'
+    pipeline_uid = aet.active_pipeline_uid
+    url = f'{BASE_API}/variables?name={variable_name}&pipeline_uid={pipeline_uid}'
 
     response = requests.get(url)
+    response.raise_for_status()
     flog.info(f'GET Variable by name response: {response.text}')
 
     return response


### PR DESCRIPTION
Dependencies:
- [https://github.com/ForloopAI/forloop_platform/pull/755](url)
- [https://github.com/ForloopAI/forloop_common_structures/pull/1](url)

This PR introduces:
- `set_project_and_pipeline_uid()` method in AET used by `ExecutionCore`
- corrected `get_variable_by_name()` - now it requires variable `name` and `active_pipeline_uid`. Just `name` is not enough, there can be variables with the same name across different pipelines.